### PR TITLE
chore: Allow empty string with pattern

### DIFF
--- a/src/configEnvParsers.ts
+++ b/src/configEnvParsers.ts
@@ -20,10 +20,11 @@ export const getStringFromEnvParser = (
   } = {}
 ) => () => {
   const envValue = process.env[envName]?.trim()
-  if (envValue === undefined || (!allowEmptyString && envValue.length === 0)) {
+  const isValueDisallowed = !allowEmptyString && envValue?.length === 0
+  if (envValue === undefined || isValueDisallowed) {
     throw new ValidationError('Value is not set or it is empty string', envName)
   }
-  if (pattern) {
+  if (pattern && isValueDisallowed) {
     const validator = new RegExp(pattern)
     if (validator.test(envValue) === false) {
       throw new ValidationError(`Value does not match the regex pattern ${pattern}`, envName)

--- a/tests/validateConfig.spec.ts
+++ b/tests/validateConfig.spec.ts
@@ -25,6 +25,7 @@ const testEnvironmentVariables = {
   ENV_NODE_ARR_STR_3: '["a", null, "b"]',
   ENV_NODE_ARR_FLOAT: '[1, 1.1, 1.11]',
   ENV_NODE_ARR_INT: '[1, 1, 1]',
+  ENV_EMPTY: '',
 }
 
 // original env  - put it back after tests done to not interferes with another tests that may use env
@@ -77,6 +78,11 @@ describe('validateConfig', () => {
         arrStr3: getListFromEnvParser('ENV_NODE_ARR_STR_3'),
         arrFloat: getListFromEnvParser('ENV_NODE_ARR_FLOAT', parseFloat),
         arrInt: getListFromEnvParser('ENV_NODE_ARR_INT', parseInt),
+        empty: getStringFromEnvParser('ENV_EMPTY', { allowEmptyString: true }),
+        emptyWithPattern: getStringFromEnvParser('ENV_EMPTY', {
+          allowEmptyString: true,
+          pattern: `https?://*.`,
+        }),
       }
 
       const parsedConfig = {
@@ -100,6 +106,8 @@ describe('validateConfig', () => {
         arrStr3: ['a', 'null', 'b'],
         arrFloat: [1, 1.1, 1.11],
         arrInt: [1, 1, 1],
+        empty: '',
+        emptyWithPattern: '',
       }
       expect(validateConfig(configValidators)).toStrictEqual(parsedConfig)
     })


### PR DESCRIPTION
This PR fixes an issue where calling `getStringFromEnvParser` function with `allowEmptyString` and `pattern` options caused an error to be thrown if the input was an empty string

With this change, it is now possible to pass an empty string and specify the pattern option without causing an error.

*POC with `process.env.ENV` is empty string*
```
getStringFromEnvParser('ENV', {
  allowEmptyString: true,
  pattern: 'https://*.',
})
```

**Before**
Throws an error if `process.env.ENV` is an empty string.

**After**
No longer throws an error if `process.env.ENV` is an empty string.




